### PR TITLE
Fixed cross-compilation for yara dependency

### DIFF
--- a/deps/CMakeLists.txt
+++ b/deps/CMakeLists.txt
@@ -59,6 +59,7 @@ if(NOT TARGET yara)
 				--prefix=${YARA_INSTALL_DIR}
 				--disable-shared
 				--without-crypto
+				CC=${CMAKE_C_COMPILER}
 		)
 	endif()
 


### PR DESCRIPTION
`yara` subproject couldn't be cross-compiled. Passing `CC` variable to the `./configure` script fixes this issue.